### PR TITLE
Set version of LanguageTool to 6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ lxml>=4.9.3
 spacy>=3.7.2,<4.0.0
 de_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl
 git+ssh://git@github.com/ybracke/textalign
-language-tool-python>=2.7.3
+language-tool-python>=2.8

--- a/src/transnormer_data/modifier/language_tool_modifier.py
+++ b/src/transnormer_data/modifier/language_tool_modifier.py
@@ -31,7 +31,9 @@ class LanguageToolModifier(BaseDatasetModifier):
         self.nlp = spacy.blank("de")
 
         # LanguageTool instance
-        self.langtool: LanguageTool = LanguageTool(language="de-DE")
+        self.langtool: LanguageTool = LanguageTool(
+            language="de-DE", language_tool_download_version="6.3"
+        )
         self.set_langtool_rules(self._load_rules(rule_file))
 
     def modify_dataset(


### PR DESCRIPTION
Background: Some rules and many RuleIDs changed between v6.3 and v6.4 and my personal rule list is currently based on v6.3. Thus, in general, we could make the LT version flexible. This now possible in language_tool_python, see PR [#82](https://github.com/jxmorris12/language_tool_python/pull/86). Note that, because of a mistake in the language_tool_python code, the program will print "Downloading LanguageTool 6.4", regardless of the version that is specified via LanguageTool(language_tool_download_version).